### PR TITLE
Remove the Test Failed label automatically

### DIFF
--- a/.github/workflows/run_integration_tests.yaml
+++ b/.github/workflows/run_integration_tests.yaml
@@ -124,9 +124,13 @@ jobs:
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: Test Failed
-      - name: Removed Reviewed Label
+      - name: Remove Reviewed Label
         if: ${{ always() }}
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: Manually Reviewed
-
+      - name: Remove Test Failed Label
+        if: ${{ !failure() }}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: Test Failed


### PR DESCRIPTION
In case the integration tests failed the workflow will add a Test Failed
label to the PR. This changes deletes that label after the integration
tests ran successfully.

# **Description**

If the integration tests were failing and afterwards they passed, the test failed label was still kept on the PR. This changes
the behavior and deletes the label.

## **Type of change**

*  Bug fix (non-breaking change which fixes an issue)

# **Checklist**

* My code follows the style guidelines of this project.
* I have performed a self-review of my own code.
*  I have commented my code, particularly in hard-to-understand areas.
* I have made corresponding changes to the documentation.
* My changes generate no new warnings.
* I have added tests that prove my fix is effective or that my feature works.
* New and existing unit tests pass locally with my changes.

