### PR TITLE
[Python] Retrieve the list of signed headers from the generated presigned URL instead of using a hardcoded list

### DIFF
--- a/function/python_3_9/src/request/utils.py
+++ b/function/python_3_9/src/request/utils.py
@@ -3,6 +3,18 @@ from urllib.parse import parse_qsl
 
 PART_NUMBER = 'partNumber'
 RANGE = 'Range'
+SIGNED_HEADERS = 'X-Amz-SignedHeaders'
+
+
+def get_signed_headers_from_url(url):
+    """
+    Get list of signed headers from user request
+    :param url: url
+    :return: list of signed headers or empty list
+    """
+    signed_headers_as_str = get_query_param(url, SIGNED_HEADERS)
+    signed_headers = signed_headers_as_str.split(';') if signed_headers_as_str is not None else []
+    return list(map(lambda x: x.lower(), signed_headers))
 
 
 def get_part_number(user_request):


### PR DESCRIPTION
# **Description**

Retrieve the list of signed headers from the generated presigned URL instead of using a hardcoded list.

## **Type of change**

*  New feature (non-breaking change which adds functionality)

# **How Has This Been Tested?**

Ran GetObject integration tests against local environment

# **Checklist**

* My code follows the style guidelines of this project.
* I have performed a self-review of my own code.
*  I have commented my code, particularly in hard-to-understand areas.
* I have made corresponding changes to the documentation.
* My changes generate no new warnings.
* I have added tests that prove my fix is effective or that my feature works.
* New and existing unit tests pass locally with my changes.

