### PR TITLE
[nodeJS] Retrieve the list of signed headers from the generated presigned URL instead of using a hardcoded list

### DIFF
--- a/function/nodejs_20_x/tst/request/utils.test.ts
+++ b/function/nodejs_20_x/tst/request/utils.test.ts
@@ -1,5 +1,52 @@
 import { UserRequest } from '../../src/s3objectlambda_event.types';
-import { applyRangeOrPartNumber, getPartNumber, getRange } from '../../src/request/utils';
+import { applyRangeOrPartNumber, getPartNumber, getRange, getSignedHeaders } from '../../src/request/utils';
+
+test('GetSignedHeaders works for a URL with a single signed header', () => {
+
+  const presigned_url: string = 'https://test-access-point-012345678901.s3-accesspoint.us-east-1.amazonaws.com/test?' +
+        'X-Amz-Security-Token=TestToken' +
+        '&X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+        '&X-Amz-Date=20250220T175710Z' +
+        '&X-Amz-SignedHeaders=host%3Bx-amz-checksum-mode' +
+        '&X-Amz-Expires=61' +
+        '&X-Amz-Credential=AKIAEXAMPLE/20250220/us-east-1/s3/aws4_request' +
+        '&X-Amz-Signature=a7f9b2c8e4d1f3a6b5c9e2d7a8f4b3c1d6e5f2a9b7c8d3e1f6a2b9c7d5e8f3a1';
+
+  const result = getSignedHeaders(presigned_url);
+  expect(result.length).toBe(2);
+  expect(result[0]).toBe("host");
+  expect(result[1]).toBe("x-amz-checksum-mode");
+});
+
+test('GetSignedHeaders works for a URL with a 2 signed headers', () => {
+
+  const presigned_url: string = 'https://test-access-point-012345678901.s3-accesspoint.us-east-1.amazonaws.com/test?' +
+      'X-Amz-Security-Token=TestToken' +
+      '&X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+      '&X-Amz-Date=20250220T175710Z' +
+      '&X-Amz-SignedHeaders=host' +
+      '&X-Amz-Expires=61' +
+      '&X-Amz-Credential=AKIAEXAMPLE/20250220/us-east-1/s3/aws4_request' +
+      '&X-Amz-Signature=a7f9b2c8e4d1f3a6b5c9e2d7a8f4b3c1d6e5f2a9b7c8d3e1f6a2b9c7d5e8f3a1';
+
+  const result = getSignedHeaders(presigned_url);
+  expect(result.length).toBe(1);
+  expect(result[0]).toBe("host");
+});
+
+test('GetSignedHeaders works for a URL with no signed headers', () => {
+
+  const presigned_url: string = 'https://test-access-point-012345678901.s3-accesspoint.us-east-1.amazonaws.com/test?' +
+      'X-Amz-Security-Token=TestToken' +
+      '&X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+      '&X-Amz-Date=20250220T175710Z' +
+      '&X-Amz-Expires=61' +
+      '&X-Amz-Credential=AKIAEXAMPLE/20250220/us-east-1/s3/aws4_request' +
+      '&X-Amz-Signature=a7f9b2c8e4d1f3a6b5c9e2d7a8f4b3c1d6e5f2a9b7c8d3e1f6a2b9c7d5e8f3a1';
+
+  const result = getSignedHeaders(presigned_url);
+  expect(result.length).toBe(0);
+});
 
 test('Get PartNumber works', () => {
   const userRequest: UserRequest = { url: 'https://s3.amazonaws.com?partNumber=1', headers: { h1: 'v1' } };


### PR DESCRIPTION
# **Description**
[nodeJS] Retrieve the list of signed headers from the generated presigned URL instead of using a hardcoded list

## **Type of change**

Please delete options that are not relevant.

*  New feature (non-breaking change which adds functionality)

# **How Has This Been Tested?**

* Added new unit tests for parsing presigned url
* Ran existing integration tests

# **Checklist**

* My code follows the style guidelines of this project.
* I have performed a self-review of my own code.
* I have commented my code, particularly in hard-to-understand areas.
* I have made corresponding changes to the documentation.
* My changes generate no new warnings.
* I have added tests that prove my fix is effective or that my feature works.
* New and existing unit tests pass locally with my changes.
