### PR TITLE
[Tests] Using custom function to compare ListObjectV2 responses

### DIFF
--- a/tests/src/com/amazon/s3objectlambda/defaultconfig/ObjectLambdaListV2AccessPointTest.java
+++ b/tests/src/com/amazon/s3objectlambda/defaultconfig/ObjectLambdaListV2AccessPointTest.java
@@ -23,7 +23,7 @@ public class ObjectLambdaListV2AccessPointTest extends ObjectLambdaAccessPointTe
             ListObjectsV2Response originalObject = s3Client.listObjectsV2(listObjectsRequestS3);
             Assert.assertTrue(object.sdkHttpResponse().isSuccessful());
             // Check if the request is equal to one without OL
-            Assert.assertTrue(areEqualListObjectV2Responses(object, originalObject));
+            Assert.assertTrue(object.equalsBySdkFields(originalObject));
         } catch (Exception e) {
             Assert.fail("Unexpected Errors: " + e.getMessage());
         }
@@ -46,7 +46,7 @@ public class ObjectLambdaListV2AccessPointTest extends ObjectLambdaAccessPointTe
             && Objects.equals(response2.maxKeys(), response1.maxKeys()) && response2.hasCommonPrefixes() == response1.hasCommonPrefixes()
             && Objects.equals(response2.commonPrefixes(), response1.commonPrefixes())
             && Objects.equals(response2.encodingTypeAsString(), response1.encodingTypeAsString())
-            && Objects.equals(response2.keyCount(), response1.keyCount()) && Objects.equals(response2.continuationToken(), response1.continuationToken())
+            && Objects.equals(response2.keyCount(), response1.keyCount())
             && Objects.equals(response2.startAfter(), response1.startAfter());
     }
 

--- a/tests/src/com/amazon/s3objectlambda/defaultconfig/ObjectLambdaListV2AccessPointTest.java
+++ b/tests/src/com/amazon/s3objectlambda/defaultconfig/ObjectLambdaListV2AccessPointTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Test(groups = "listV2AccessPoint", dependsOnGroups = {"setup"})
@@ -22,10 +23,31 @@ public class ObjectLambdaListV2AccessPointTest extends ObjectLambdaAccessPointTe
             ListObjectsV2Response originalObject = s3Client.listObjectsV2(listObjectsRequestS3);
             Assert.assertTrue(object.sdkHttpResponse().isSuccessful());
             // Check if the request is equal to one without OL
-            Assert.assertTrue(object.equalsBySdkFields(originalObject));
+            Assert.assertTrue(areEqualListObjectV2Responses(object, originalObject));
         } catch (Exception e) {
             Assert.fail("Unexpected Errors: " + e.getMessage());
         }
+    }
+
+    private boolean areEqualListObjectV2Responses(Object obj1, Object obj2) {
+
+        if (obj1 == obj2) {
+            return true;
+        }
+        if (obj1 == null || obj2 == null) {
+            return false;
+        }
+        if (!(obj1 instanceof ListObjectsV2Response response1) || !(obj2 instanceof ListObjectsV2Response response2)) {
+            return false;
+        }
+        return Objects.equals(response2.isTruncated(), response1.isTruncated()) && response2.hasContents() == response1.hasContents()
+            && Objects.equals(response2.contents(), response1.contents()) && Objects.equals(response2.name(), response1.name())
+            && Objects.equals(response2.prefix(), response1.prefix()) && Objects.equals(response2.delimiter(), response1.delimiter())
+            && Objects.equals(response2.maxKeys(), response1.maxKeys()) && response2.hasCommonPrefixes() == response1.hasCommonPrefixes()
+            && Objects.equals(response2.commonPrefixes(), response1.commonPrefixes())
+            && Objects.equals(response2.encodingTypeAsString(), response1.encodingTypeAsString())
+            && Objects.equals(response2.keyCount(), response1.keyCount()) && Objects.equals(response2.continuationToken(), response1.continuationToken())
+            && Objects.equals(response2.startAfter(), response1.startAfter());
     }
 
     private void assertSuccessfulResponseContents(ListObjectsV2Request listObjectsRequestOLAP,


### PR DESCRIPTION
# **Description**

[Tests] Using custom function to compare ListObjectV2 responses

Fixes # (issue)

Integration tests for ListObjectV2 API are currently failing when running against buckets which hold > 1000 objects due to the way we compare responses against OLAP and S3AP.

It is done via equalsBySdkFields() method, which also compares obfuscated and randomized nextContinuationToken() field. This field is always different even across two subsequent API calls to a single AP.

Replacing equalsBySdkFields() with a custom function which only compares necessary fields to make the code future-proof.

## **Type of change**

*  Bug fix (non-breaking change which fixes an issue)

# **How Has This Been Tested?**

* Verified that NodeJS ListObjectV2 integration tests are failing for current implementation.
* Updated tests to use customer comparison function.
* Verified that NodeJS ListObjectV2 integration tests are now successful.

# **Checklist**

* My code follows the style guidelines of this project.
* I have performed a self-review of my own code.
*  I have commented my code, particularly in hard-to-understand areas.
* I have made corresponding changes to the documentation.
* My changes generate no new warnings.
* I have added tests that prove my fix is effective or that my feature works.
* New and existing unit tests pass locally with my changes.

